### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 ## Online Courses
 
 * [Coursera GCP courses](https://www.coursera.org/courses?query=gcp) Courses provided by both Google and other institutions that use GCP.  [Eligible faculty and students](https://edu.google.com/programs/credits/faqs/?modal_active=none) can get free access to 13 of the Google courses though the [Training Credits Program](https://edu.google.com/programs/credits/training/?modal_active=none).  
-* [The Machine Learning Crash Course](https://developers.google.com/machine-learning/crash-course/) Originally, an on-line public version of the training for Google engineers, this has expanded to numerous classes including problem framing, data prep, and testing and debugging.  Students get hands-on experience using Colab. 
+* [The Machine Learning Crash Course](https://developers.google.com/machine-learning/crash-course/) Originally, an on-line public version of the training for Google engineers, this has expanded to numerous classes including problem framing, data prep, and testing and debugging.  Students get hands-on experience using Colab. Along with the basic course, there are 5 specialized courses,  practica, guides, and a glossary.
+
 
 ## Books
 
@@ -15,13 +16,14 @@
 * [Data Science on Google Cloud Platform](http://amzn.com/B0787L7RK3) by Valliappa (Lak) Lakshmanan.  This book was distributed to attendees of SIGCSE 2019 and has been useful in a number of classes since then.
 
 
-## Tutorials
+## Hands-on labs/tutorials
 
 Codelabs and Qwiklabs are self-paced, hands-on tutorials.  Codelabs require students to have their own GCP account whereas Qwiklabs provide a new account for the student for each lab.  [Eligible faculty and students](https://edu.google.com/programs/credits/faqs/?modal_active=none) can get free access to Qwiklabs though the [Training Credits Program](https://edu.google.com/programs/credits/training/?modal_active=none).  
 
 * [GCP codelabs](http://g.co/codelabs/cloud)
 * [Other Google codelabs](http://g.co/codelabs)
 * [Qwiklabs](http://google.qwiklabs.com)  Along with individual labs, Qwiklabs provides Quests, groupings of individual labs that make sense together.
+
 
 ## Notebooks
 Jupyter notebooks are becoming extremely popular in many different classes, especially data science and machine learning.
@@ -40,6 +42,23 @@ contests, [learning materials for numerous topics](https://www.kaggle.com/learn/
 [Titanic](https://www.kaggle.com/eraaz1/a-comprehensive-guide-to-titanic-machine-learning) 
 and MNIST), and sample solutions. Also allows faculty to run [their own contests in class](https://www.kaggle.com/about/inclass/overview).
 
+## Solutions and Course Materials
+There are many faculty who share much of their course material on-line.  These include the following:
+* [The Database Whisperer](https://github.com/hymanphd/Database-Whisperer-Docs) Materials to go with Harvey Hyman's ISM 4212 course at USF.
+* [ART350 video experimentation toolkit](https://github.com/realtechsupport/ActionCameraCode) Materials from the Department of Art at the University of Buffalo.
+
+
+## Videos
+
+* [GCP Essentials](https://www.youtube.com/playlist?list=PLIivdWyY5sqKh1gDR0WpP9iIOY00IE0xL) A 
+series of 4 to 9 minute videos focusing on introductory level GCP, including topics such as 
+compute options, serverless computing, machine learning, and data storage.  There are currently 8 videos, 
+but they seems to add 1 per month.
+
+## Slide Decks
+
+_(coming soon)_
+
 ## Grant Programs
 GCP has a number of different grant programs, listed below.
 
@@ -51,15 +70,6 @@ GCP has a number of different grant programs, listed below.
 Here's a quick comparison of those programs.
 
 ![comparison of above edu programs](https://user-images.githubusercontent.com/1102504/59053652-c377b000-8846-11e9-90c2-70875c1c7f21.png)
-
-## Solutions and Course Materials
-There are many faculty who share much of their course material on-line.  These include the following:
-* [The Database Whisperer](https://github.com/hymanphd/Database-Whisperer-Docs) Materials to go with Harvey Hyman's ISM 4212 course at USF.
-* [ART350 video experimentation toolkit](https://github.com/realtechsupport/ActionCameraCode) Materials from the Department of Art at the University of Buffalo.
-
-## Slide Decks
-
-_(coming soon)_
 
 ## Working with other public clouds
 GCP isn't the only public cloud out there. It's a vibrant market with many vendors. Below are resources to consider when working with other public clouds.


### PR DESCRIPTION
Dang, I did this to the main, not the branch.  Sorry.

Moved Grant Programs down--it takes up a lot of space and is only typically needed once.

Add GCP Essentials and  Video category.  

Renamed Tutorials to Hands-on labs/tutorials.  But I'm not sure that's right.  We're gonna have to rethink this organization a few times, I think.

